### PR TITLE
Updates to add admin widgets

### DIFF
--- a/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetCounterHistory.php
+++ b/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetCounterHistory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * zcDashboardWidgetCounterHistory Class.
+ *
+ * @package classes
+ * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version GIT: $Id: Author: Scott Wilson  Fri Aug 17 17:42:37 2012 +0100 New in v1.5.1 $
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+/**
+ * zcDashboardWidgetCounterHistory Class
+ *
+ * @package classes
+ */
+class zcDashboardWidgetCounterHistory extends zcDashboardWidgetBase
+{
+  public function prepareContent() 
+  {
+    global $db;
+
+    $counter_query = "select startdate, counter, session_counter from " . TABLE_COUNTER_HISTORY . " order by startdate DESC limit 10";
+    $counter = $db->Execute($counter_query);
+    while (!$counter->EOF) {
+      $counter_startdate = $counter->fields['startdate'];
+      $counter_startdate_formatted = strftime(DATE_FORMAT_SHORT, mktime(0, 0, 0, substr($counter_startdate, 4, 2), substr($counter_startdate, -2), substr($counter_startdate, 0, 4)));
+      $counter_info = $counter->fields['session_counter'] . ' - ' . $counter->fields['counter']; 
+      $tplVars['content'][] = array('text'=> $counter_startdate_formatted, 'value'=>$counter_info);
+      $counter->MoveNext();
+    }
+    return $tplVars;
+  }
+}

--- a/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetNewCustomers.php
+++ b/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetNewCustomers.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * zcDashboardWidgetNewCustomers Class.
+ *
+ * @package classes
+ * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version GIT: $Id: Author: Scott Wilson  Fri Aug 17 17:42:37 2012 +0100 New in v1.5.1 $
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+/**
+ * zcDashboardWidgetNewCustomers Class
+ *
+ * @package classes
+ */
+class zcDashboardWidgetNewCustomers extends zcDashboardWidgetBase
+{
+  public function prepareContent() 
+  {
+    global $db;
+
+    $customers = $db->Execute("select c.customers_id as customers_id, c.customers_firstname as customers_firstname, c.customers_lastname as customers_lastname, c.customers_email_address as customers_email_address, a.customers_info_date_account_created as customers_info_date_account_created, a.customers_info_id from " . TABLE_CUSTOMERS . " c left join " . TABLE_CUSTOMERS_INFO . " a on c.customers_id = a.customers_info_id order by a.customers_info_date_account_created DESC limit 5");
+    while (!$customers->EOF) {
+       $name = $customers->fields['customers_firstname'] . ' ' . $customers->fields['customers_lastname']; 
+       $date_created = zen_date_short($customers->fields['customers_info_date_account_created']);
+       $tplVars['content'][] = array('text'=> '<a href="' . zen_href_link(FILENAME_CUSTOMERS, 'search=' . $customers->fields['customers_email_address'], 'NONSSL') . '">' . $name . '</a>', 'value'=>$date_created);
+       $customers->MoveNext();
+    }
+
+    return $tplVars;
+  }
+}

--- a/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetNewOrders.php
+++ b/admin/includes/classes/dashboardWidgets/class.zcDashboardWidgetNewOrders.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * zcDashboardWidgetNewOrders Class.
+ *
+ * @package classes
+ * @copyright Copyright 2003-2013 Zen Cart Development Team
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version GIT: $Id: Author: Scott Wilson  Fri Aug 17 17:42:37 2012 +0100 New in v1.5.1 $
+ */
+if (!defined('IS_ADMIN_FLAG')) {
+  die('Illegal Access');
+}
+/**
+ * zcDashboardWidgetNewOrders Class
+ *
+ * @package classes
+ */
+class zcDashboardWidgetNewOrders extends zcDashboardWidgetBase
+{
+  public function prepareContent() 
+  {
+    global $db;
+
+    $orders = $db->Execute("select o.orders_id as orders_id, o.customers_name as customers_name, o.customers_id, o.date_purchased as date_purchased, o.currency, o.currency_value, ot.class, ot.text as order_total from " . TABLE_ORDERS . " o left join " . TABLE_ORDERS_TOTAL . " ot on (o.orders_id = ot.orders_id and class = 'ot_total') order by orders_id DESC limit 5");
+
+    while (!$orders->EOF) {
+      $name = $orders->fields['customers_name'];
+      $order_value = $orders->fields['order_total'];
+      $order_date = zen_date_short($orders->fields['date_purchased']);
+      $tplVars['content'][] = array('text'=> '<a href="' . zen_href_link(FILENAME_ORDERS, 'oID=' . $orders->fields['orders_id'], 'NONSSL') . '">' . $name . '</a><br />' . $order_date, 'value'=>$order_value);
+      $orders->MoveNext();
+    }
+    return $tplVars;
+  }
+}

--- a/admin/includes/template/dashboardWidgets/tplDefault.php
+++ b/admin/includes/template/dashboardWidgets/tplDefault.php
@@ -8,6 +8,12 @@
  * @version GIT: $Id: Author: DrByte  Sun Aug 5 20:48:10 2012 -0400 Modified in v1.5.1 $
  */
 ?>
-  <?php foreach ($tplVars['widget']['content'] as $entry) { ?>
+<?php
+  if (sizeof($tplVars['widget']['content']) > 0) { 
+    foreach ($tplVars['widget']['content'] as $entry) { 
+?>
       <div class="widget-row"><span><?php echo $entry['text']; ?></span><span class="right"><?php echo $entry['value']; ?></span></div>
-  <?php } ?>
+<?php
+    }
+  }
+?>

--- a/includes/init_includes/init_counter.php
+++ b/includes/init_includes/init_counter.php
@@ -15,8 +15,8 @@ if (!defined('IS_ADMIN_FLAG')) {
  * update counter and counter history if appropriate
  **/
 $update_counter = TRUE;
-if ($spider_flag == false) $update_counter = FALSE;
-if (!strstr(EXCLUDE_ADMIN_IP_FOR_MAINTENANCE, $_SERVER['REMOTE_ADDR'])) $update_counter = FALSE;
+if ($spider_flag) $update_counter = FALSE;
+if (strstr(EXCLUDE_ADMIN_IP_FOR_MAINTENANCE, $_SERVER['REMOTE_ADDR']) !== FALSE) $update_counter = FALSE;
 
 if ($update_counter == TRUE) {
   if (isset($_SESSION['session_counter']) && $_SESSION['session_counter'] == true) {

--- a/zc_install/sql/install/mysql_zencart.sql
+++ b/zc_install/sql/install/mysql_zencart.sql
@@ -3289,19 +3289,35 @@ INSERT INTO get_terms_to_filter VALUES ('record_company_id', 'TABLE_RECORD_COMPA
 #
 INSERT INTO dashboard_widgets (widget_key, widget_group, widget_status) VALUES
 ('general-statistics', 'general-statistics', 1),
-('order-summary', 'order-statistics', 1);
+('order-summary', 'order-statistics', 1), 
+('new-customers', 'new-customers', 1), 
+('counter-history', 'counter-history', 1),
+('new-orders', 'new-orders', 1)
+;
 
 INSERT INTO dashboard_widgets_description (widget_key, widget_name, widget_description, language_id) VALUES
 ('general-statistics', 'General Statistics', '', 1),
-('order-summary', 'Order Summary', '', 1);
+('order-summary', 'Order Summary', '', 1),
+('new-customers', 'New Customers', '', 1),
+('counter-history', 'Counter History', '', 1),
+('new-orders', 'New Orders', '', 1)
+;
 
 INSERT INTO dashboard_widgets_groups (widget_group, language_id, widget_group_name) VALUES
 ('general-statistics', 1, 'General Statistics'),
-('order-statistics', 1, 'Order Statistics');
+('order-statistics', 1, 'Order Statistics'),
+('new-customers', 1, 'New Customers'),
+('counter-history', 1, 'Counter History'),
+('new-orders', 1, 'New Orders')
+;
 
 INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget_column) VALUES
 ('general-statistics', 1, 0, 0),
-('order-summary', 1, 0, 1);
+('order-summary', 1, 1, 0),
+('new-customers', 1, 0, 1),
+('counter-history', 1, 1, 1),
+('new-orders', 1, 0, 2)
+;
 
 
 

--- a/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
+++ b/zc_install/sql/updates/mysql_upgrade_zencart_160.sql
@@ -180,22 +180,35 @@ CREATE TABLE IF NOT EXISTS dashboard_widgets_to_users (
 #
 INSERT INTO dashboard_widgets (widget_key, widget_group, widget_status) VALUES
 ('general-statistics', 'general-statistics', 1),
-('order-summary', 'order-statistics', 1);
+('order-summary', 'order-statistics', 1), 
+('new-customers', 'new-customers', 1), 
+('counter-history', 'counter-history', 1),
+('new-orders', 'new-orders', 1)
+;
 
 INSERT INTO dashboard_widgets_description (widget_key, widget_name, widget_description, language_id) VALUES
 ('general-statistics', 'General Statistics', '', 1),
-('order-summary', 'Order Summary', '', 1);
+('order-summary', 'Order Summary', '', 1),
+('new-customers', 'New Customers', '', 1),
+('counter-history', 'Counter History', '', 1),
+('new-orders', 'New Orders', '', 1)
+;
 
 INSERT INTO dashboard_widgets_groups (widget_group, language_id, widget_group_name) VALUES
 ('general-statistics', 1, 'General Statistics'),
-('order-statistics', 1, 'Order Statistics');
+('order-statistics', 1, 'Order Statistics'),
+('new-customers', 1, 'New Customers'),
+('counter-history', 1, 'Counter History'),
+('new-orders', 1, 'New Orders')
+;
 
-
-# default widgets for first user
 INSERT INTO dashboard_widgets_to_users (widget_key, admin_id, widget_row, widget_column) VALUES
 ('general-statistics', 1, 0, 0),
-('order-summary', 1, 0, 1);
-
+('order-summary', 1, 1, 0),
+('new-customers', 1, 0, 1),
+('counter-history', 1, 1, 1),
+('new-orders', 1, 0, 2)
+;
 
 ## CHANGE-346 - Fix outdated language in configuration menu help texts
 ## CHANGE-411 increase size of fileds in admin profile related tables


### PR DESCRIPTION
Adds column 1 - new customers and counter history
Adds column 2 - new orders
Fixes bugs in dashboard widgets with 0 rows (initially counter had 0 rows).
Fixes bugs in counter logic (made counter work)

Merged into Zen Cart 1.6.0 by Wilt: 
https://github.com/zencart/zc-v1-series/commit/5a2f19ae8c07b7490bbbc9c204dd0bdcae46d35f
